### PR TITLE
PAPP-29231: Add an optional file extension allowlist for 'deflate item'

### DIFF
--- a/phantom.json
+++ b/phantom.json
@@ -17,7 +17,7 @@
     "product_vendor": "Phantom",
     "product_name": "Phantom",
     "product_version_regex": ".*",
-    "min_phantom_version": "5.3.0",
+    "min_phantom_version": "5.2.0",
     "fips_compliant": true,
     "license": "Copyright (c) 2016-2023 Splunk Inc.",
     "logo": "logo_splunk.svg",

--- a/phantom.json
+++ b/phantom.json
@@ -63,8 +63,7 @@
         "deflate_item_extensions": {
             "data_type": "string",
             "order": 5,
-            "description": "Only files with the specified extensions (comma-separated) will be deflated. If blank, file extension will not be checked",
-            "default": "bz,bz2,bzip,bzip2,gz,gzip,tar,tgz,zip"
+            "description": "Only files with the specified extensions (comma-separated) will be deflated. If blank, file extension will not be checked"
         }
     },
     "actions": [

--- a/phantom.json
+++ b/phantom.json
@@ -59,6 +59,12 @@
             "order": 4,
             "description": "Verify HTTPS certificate (default: false)",
             "default": false
+        },
+        "deflate_item_extensions": {
+            "data_type": "string",
+            "order": 5,
+            "description": "Only files with the specified extensions (comma-separated) will be deflated. If blank, file extension will not be checked",
+            "default": "bz,bz2,bzip,bzip2,gz,gzip,tar,tgz,zip"
         }
     },
     "actions": [

--- a/phantom.json
+++ b/phantom.json
@@ -6,7 +6,7 @@
     "publisher": "Splunk",
     "type": "information",
     "main_module": "phantom_connector.py",
-    "app_version": "3.6.0",
+    "app_version": "3.6.1",
     "latest_tested_versions": [
         "Splunk Phantom PlatformAPI v5.3.1",
         "SOAR On-prem v5.3.1.84890",
@@ -17,9 +17,9 @@
     "product_vendor": "Phantom",
     "product_name": "Phantom",
     "product_version_regex": ".*",
-    "min_phantom_version": "5.2.0",
+    "min_phantom_version": "5.3.0",
     "fips_compliant": true,
-    "license": "Copyright (c) 2016-2022 Splunk Inc.",
+    "license": "Copyright (c) 2016-2023 Splunk Inc.",
     "logo": "logo_splunk.svg",
     "contributors": [
         {

--- a/phantom_connector.py
+++ b/phantom_connector.py
@@ -871,6 +871,7 @@ class PhantomConnector(BaseConnector):
                     # but is not a standard zip file. (e.g. xlsx is application/zip) but if
                     # we unzip it we will have possibly hundreds of small garbage files
                     if self._is_ooxml_zip(archived_files):
+                        self.debug_print(f'Skipping extraction of OOXML archive file: {file_name}')
                         return phantom.APP_SUCCESS
 
                     for compressed_file in archived_files:

--- a/phantom_connector.py
+++ b/phantom_connector.py
@@ -809,11 +809,12 @@ class PhantomConnector(BaseConnector):
 
         return (phantom.APP_SUCCESS)
 
-    @classmethod
-    def _is_ooxml_zip(cls, member_filenames):
+    @staticmethod
+    def _is_ooxml_zip(member_filenames):
         return OOXML_FILES.issubset(member_filenames)
 
-    def _has_allowed_archive_extension(self, file_name, allowed_extensions):
+    @staticmethod
+    def _has_allowed_archive_extension(file_name, allowed_extensions):
         if allowed_extensions:
             allowed_extension_suffixes = set(allowed_extensions.split(','))
             file_extension = Path(file_name).suffix.lstrip('.')
@@ -882,13 +883,6 @@ class PhantomConnector(BaseConnector):
                         vault_file.setpassword(password.encode())
 
                     archived_files = vault_file.namelist()
-
-                    # The Office Document format is application/zip per file
-                    # but is not a standard zip file. (e.g. xlsx is application/zip) but if
-                    # we unzip it we will have possibly hundreds of small garbage files
-                    if self._is_ooxml_zip(archived_files):
-                        self.debug_print(f'Skipping extraction of OOXML archive file: {file_name}')
-                        return phantom.APP_SUCCESS
 
                     for compressed_file in archived_files:
 

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* [PAPP-29231] Ignore OOXML files in deflate action

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,2 +1,2 @@
 **Unreleased**
-* [PAPP-29231] Ignore OOXML files in deflate action
+* [PAPP-29231] Add an optional file extension allowlist for 'deflate item'


### PR DESCRIPTION
Fix for SOARHELP-1529/PAPP-29231.

Ignore OOXML files when deflating zip archives. Detection is based on the expected existence of a certain set of files which should exist in OOXML archives.

Without this change, these files get deflated into potentially thousands of individual spreadsheets which can strain system resources.