### PR TITLE
Fix python_version format

### DIFF
--- a/phantom.json
+++ b/phantom.json
@@ -12,10 +12,7 @@
         "SOAR On-prem v6.3.1.176",
         "SOAR Cloud v6.3.1.176"
     ],
-    "python_version": [
-        "3.9",
-        "3.13"
-    ],
+    "python_version": "3.9, 3.13",
     "utctime_updated": "2025-07-30T17:51:42.931698Z",
     "product_vendor": "Phantom",
     "product_name": "Phantom",

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Fix python_version 3.13 format


### PR DESCRIPTION
- Fix python_version format in app JSON files from array `["3.9", "3.13"]` to string `"3.9, 3.13"`

[_Created by Sourcegraph batch change `grokas-splunk/003-fix-python-version-format`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/003-fix-python-version-format)